### PR TITLE
Add vim-stay integration module

### DIFF
--- a/autoload/stay/integrate/fastfold.vim
+++ b/autoload/stay/integrate/fastfold.vim
@@ -12,25 +12,19 @@ endfunction
 
 " - on User event 'BufStaySavePre': restore original 'foldmethod'
 function! stay#integrate#fastfold#save_pre() abort
-  let [l:fdmlocal, l:fdmorig] = s:foldmethods()
-  if l:fdmorig isnot l:fdmlocal
-\ && index(split(&viewoptions, ','), 'folds') isnot -1
-    noautocmd silent let &l:foldmethod = l:fdmorig
+  if index(split(&viewoptions, ','), 'folds') isnot -1
+    let [l:fdmlocal, l:fdmorig] = [&l:foldmethod, get(w:, 'lastfdm', &l:foldmethod)]
+    if l:fdmorig isnot l:fdmlocal
+      noautocmd silent let &l:foldmethod = l:fdmorig
+    endif
   endif
 endfunction
 
 " - on User event 'BufStaySavePost': restore FastFold 'foldmethod'
 function! stay#integrate#fastfold#save_post() abort
-  let [l:fdmlocal, l:fdmorig] = s:foldmethods()
-  if l:fdmorig isnot l:fdmlocal
+  if &foldmethod isnot# 'manual' && exists('w:lastfdm')
     noautocmd silent let &l:foldmethod = 'manual'
   endif
-endfunction
-
-" - return tuple of current local and FastFold stored 'foldmethod'
-function! s:foldmethods() abort
-  let l:fdmlocal = &l:foldmethod
-  return [l:fdmlocal, get(w:, 'lastfdm', l:fdmlocal)]
 endfunction
 
 let &cpoptions = s:cpoptions

--- a/autoload/stay/integrate/fastfold.vim
+++ b/autoload/stay/integrate/fastfold.vim
@@ -1,0 +1,39 @@
+" VIM-STAY INTEGRATION MODULE
+" https://github.com/kopischke/vim-stay
+let s:cpoptions = &cpoptions
+set cpoptions&vim
+
+" - register integration autocommands
+function! stay#integrate#fastfold#setup() abort
+  autocmd User BufStaySavePre  unsilent call stay#integrate#fastfold#save_pre()
+  autocmd User BufStaySavePost unsilent call stay#integrate#fastfold#save_post()
+  autocmd User BufStayLoadPost,BufStaySavePost let b:isPersistent = 1
+endfunction
+
+" - on User event 'BufStaySavePre': restore original 'foldmethod'
+function! stay#integrate#fastfold#save_pre() abort
+  let [l:fdmlocal, l:fdmorig] = s:foldmethods()
+  if l:fdmorig isnot l:fdmlocal
+\ && index(split(&viewoptions, ','), 'folds') isnot -1
+    noautocmd silent let &l:foldmethod = l:fdmorig
+  endif
+endfunction
+
+" - on User event 'BufStaySavePost': restore FastFold 'foldmethod'
+function! stay#integrate#fastfold#save_post() abort
+  let [l:fdmlocal, l:fdmorig] = s:foldmethods()
+  if l:fdmorig isnot l:fdmlocal
+    noautocmd silent let &l:foldmethod = 'manual'
+  endif
+endfunction
+
+" - return tuple of current local and FastFold stored 'foldmethod'
+function! s:foldmethods() abort
+  let l:fdmlocal = &l:foldmethod
+  return [l:fdmlocal, get(w:, 'lastfdm', l:fdmlocal)]
+endfunction
+
+let &cpoptions = s:cpoptions
+unlet! s:cpoptions
+
+" vim:set sw=2 sts=2 ts=2 et fdm=marker fmr={{{,}}}:


### PR DESCRIPTION
As a follow up to [our discussion](https://github.com/kopischke/vim-stay/issues/9), I think the *vim-stay* integration module **really** belongs into *FastFold* – *FastFold*’s API is obviously far more fluid than *vim-stay*’s, and this would give you the necessary liberty to iterate rapidly, while relieving me from tracking same iterations, ensuring changes in *FastFold* are immediately reflected in its *vim-stay* integration, not coupled to a new *vim-stay* release. Oh, and it will enable you to brag you are supporting *vim-stay* “out of the box” :).

The *vim-stay* integration API is [documented](https://github.com/kopischke/vim-stay/blob/master/doc/vim-stay.txt#L106-L123) and will remain stable in version 1 (I know Vim plug-in developers rarely adhere to  stringent versioning and release schemes, never mind considering themselves bound by API contracts, but I do uphold all of these obligations for my plug-ins). Should the major version of *vim-stay* ever change, I’ll gladly help updating integration / update it myself.