### PR TITLE
Use keepjumps modifier in WinDo()

### DIFF
--- a/plugin/fastfold.vim
+++ b/plugin/fastfold.vim
@@ -55,7 +55,7 @@ function! s:WinDo( command )
   " See https://groups.google.com/forum/#!topic/vim_dev/LLTw8JV6wKg
   let curaltwin = winnr('#') ? winnr('#') : 1
   let currwin=winnr()
-  execute 'noautocmd windo ' . a:command
+  execute 'keepjumps noautocmd windo ' . a:command
   execute curaltwin . 'wincmd w'
   execute currwin . 'wincmd w'
 endfunction


### PR DESCRIPTION
0c830e78099e3309a6443b6d0d691aa0ce4cb13d sort of broke the behavior of `<C-o>` (go to previous position in jump list). For example, pressing `<C-o>` after `<C-^>` should return to buffer A after switching to buffer B. Another example is `<C-o>` after closing a buffer should re-open the closed buffer. The aforementioned commit made it take two presses of `<C-o>` to do those things.

Adding `keepjumps` to the `noautocmd windo` command in `WinDo()` solves the problem by not adding an extra entry to the jump list.