### PR TITLE
Don't update folds for the command line window

### DIFF
--- a/plugin/fastfold.vim
+++ b/plugin/fastfold.vim
@@ -62,6 +62,7 @@ endfunction
 
 " WinEnter then TabEnter then BufEnter then BufWinEnter
 function! s:UpdateWin(check)
+  if pumvisible() == 0 | return | endif
   " skip if another session still loading
   if a:check && exists('g:SessionLoad') | return | endif
 
@@ -85,6 +86,7 @@ function! s:UpdateBuf(feedback)
 endfunction
 
 function! s:UpdateTab()
+  if pumvisible() == 0 | return | endif
   " skip if another session still loading
   if exists('g:SessionLoad') | return | endif
 

--- a/plugin/fastfold.vim
+++ b/plugin/fastfold.vim
@@ -86,7 +86,6 @@ function! s:UpdateBuf(feedback)
 endfunction
 
 function! s:UpdateTab()
-  if pumvisible() == 0 | return | endif
   " skip if another session still loading
   if exists('g:SessionLoad') | return | endif
 


### PR DESCRIPTION
This fixes the spew of error messages caused by FastFold when opening the command line window.