### PR TITLE
Fix flicker with popup menu

### DIFF
--- a/plugin/fastfold.vim
+++ b/plugin/fastfold.vim
@@ -155,11 +155,15 @@ function! s:augroup()
     " UpdateWin(1) = Skip if another session still loading.
     " BufWinEnter = to change &l:foldmethod by modelines.
     autocmd BufWinEnter,BufEnter,WinEnter *
-      \ if exists('b:lastfdm') | let w:lastfdm = b:lastfdm | call s:LeaveWin() | call s:EnterWin() | endif
+      \ if !pumvisible() |
+      \   if exists('b:lastfdm') | let w:lastfdm = b:lastfdm | call s:LeaveWin() | call s:EnterWin() | endif |
+      \ endif
     autocmd BufLeave,WinLeave             *
-      \ call s:LeaveWin() | call s:EnterWin() |
-      \ if exists('w:lastfdm')     | let b:lastfdm = w:lastfdm |
-      \ elseif exists('b:lastfdm') | unlet b:lastfdm | endif
+      \ if !pumvisible() |
+      \   call s:LeaveWin() | call s:EnterWin() |
+      \   if exists('w:lastfdm')     | let b:lastfdm = w:lastfdm |
+      \   elseif exists('b:lastfdm') | unlet b:lastfdm | endif |
+      \ endif
 
     autocmd FileType                      * call s:UpdateWin(1)
     " So that FastFold functions correctly after :loadview.


### PR DESCRIPTION
When using the completion menu if a menu item has additional infos associated, a preview window is opened to show these.
When the preview window is shown the cursor is briefly switched to the preview window and back to its original position thus triggering a BufLeave and corresponding BufEnter command. This can cause a function call, that may trigger a redraw causing a flicker while moving between popup menu result. Only executing those function when the popup menu is not visible fixes the issue.