### PR TITLE
s:WinDo: remove "jump" from "scrollopt" for "windo"

### DIFF
--- a/plugin/fastfold.vim
+++ b/plugin/fastfold.vim
@@ -68,14 +68,14 @@ endfunction
 " Like windo but restore the current buffer.
 " See http://vim.wikia.com/wiki/Run_a_command_in_multiple_buffers#Restoring_position
 function! s:WinDo( command )
-  " Work around Vim bug.
-  " See https://groups.google.com/forum/#!topic/vim_dev/LLTw8JV6wKg
-  let curaltwin = winnr('#') ? winnr('#') : 1
-  let currwin=winnr()
   " avoid errors in CmdWin
   if exists('*getcmdwintype') && !empty(getcmdwintype())
     return
   endif
+  " Work around Vim bug.
+  " See https://groups.google.com/forum/#!topic/vim_dev/LLTw8JV6wKg
+  let curaltwin = winnr('#') ? winnr('#') : 1
+  let currwin=winnr()
   if &scrollopt =~# '\<jump\>'
     set scrollopt-=jump
     let l:restore = 'set scrollopt+=jump'

--- a/plugin/fastfold.vim
+++ b/plugin/fastfold.vim
@@ -81,8 +81,8 @@ function! s:WinDo( command )
     let l:restore = 'set scrollopt+=jump'
   endif
   silent! execute 'keepjumps noautocmd windo ' . a:command
-  silent! execute curaltwin . 'wincmd w'
-  silent! execute currwin . 'wincmd w'
+  silent! execute 'noautocmd ' . curaltwin . 'wincmd w'
+  silent! execute 'noautocmd ' . currwin . 'wincmd w'
   if exists('l:restore')
     exe l:restore
   endif

--- a/plugin/fastfold.vim
+++ b/plugin/fastfold.vim
@@ -76,9 +76,16 @@ function! s:WinDo( command )
   if exists('*getcmdwintype') && !empty(getcmdwintype())
     return
   endif
+  if &scrollopt =~# '\<jump\>'
+    set scrollopt-=jump
+    let l:restore = 'set scrollopt+=jump'
+  endif
   silent! execute 'keepjumps noautocmd windo ' . a:command
   silent! execute curaltwin . 'wincmd w'
   silent! execute currwin . 'wincmd w'
+  if exists('l:restore')
+    exe l:restore
+  endif
 endfunction
 
 " WinEnter then TabEnter then BufEnter then BufWinEnter


### PR DESCRIPTION
The "jump" in "scrollopt" (set by default) might cause windows with
"scrollbind" to jump around when ":windo" is being called.

This is especially relevant for "git mergetool --tool=vimdiff".

This happens with both Vim (7.4.1910) and Neovim.