### PR TITLE
allow skipping small files

### DIFF
--- a/doc/FastFold.txt
+++ b/doc/FastFold.txt
@@ -112,6 +112,12 @@ perl files.
 <
   to your 'vimrc'. Default value is [].
 
+- To disable FastFold for files smaller than certain number of lines, add
+>
+` let g:fastfold_minlines`= 800
+<
+  to your 'vimrc'. Default value is 0 (enabled for all files).
+
 - Add a fold text-object, mapped to `iz` and `az`, by adding the lines
 
   xnoremap iz :<c-u>FastFoldUpdate<cr><esc>:<c-u>normal! ]zv[z<cr>

--- a/plugin/fastfold.vim
+++ b/plugin/fastfold.vim
@@ -29,6 +29,7 @@ if !exists('g:fastfold_savehook')       | let g:fastfold_savehook       = 1  | e
 if !exists('g:fastfold_force')          | let g:fastfold_force          = 0  | endif
 
 if !exists('g:fastfold_skip_filetypes') | let g:fastfold_skip_filetypes = [] | endif
+if !exists('g:fastfold_minlines') | let g:fastfold_minlines = 0 | endif
 if !exists('g:fastfold_fold_command_suffixes')
   let g:fastfold_fold_command_suffixes = ['x','X','a','A','o','O','c','C']
 endif
@@ -123,6 +124,7 @@ function! s:UpdateTab()
 endfunction
 
 function! s:Skip()
+  if s:isSmall()       | return 1 | endif
   if !s:isReasonable() | return 1 | endif
   if !&l:modifiable    | return 1 | endif
   if s:inSkipList()    | return 1 | endif
@@ -140,6 +142,14 @@ endfunction
 
 function! s:inSkipList()
   if index(g:fastfold_skip_filetypes, &l:filetype) >= 0
+    return 1
+  else
+    return 0
+  endif
+endfunction
+
+function! s:isSmall()
+  if g:fastfold_minlines && line('$') <= g:fastfold_minlines
     return 1
   else
     return 0


### PR DESCRIPTION
FastFold is more helpful for large files, so it can be useful to avoid its overhead in small files. This can also avoid issues on buffers created by other plugins, which are usually only a handful of lines.

It was placed with the higher priority in `s:Skip()` because it will return quickly if `g:fastfold_minlines` is zero, and if it is non-zero it is a quick check that will be true for many files.