### PR TITLE
Fix the situation that "zc" isn't working

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ nmap zuz <Plug>(FastFoldUpdate)
 let g:fastfold_savehook = 1
 let g:fastfold_fold_command_suffixes =  ['x','X','a','A','o','O','c','C']
 let g:fastfold_fold_movement_commands = [']z', '[z', 'zj', 'zk']
+set foldmethod=syntax
 ```
 
 to the file `~/.vimrc` (respectively `%USERPROFILE%/_vimrc` on Microsoft Windows).


### PR DESCRIPTION
I have the situation described, which can be fixed by add the line changed.

BTW, this is part of my settings in `~/.vimrc`, and if there's something wrong instead, please let me know!😊
```vim
" installed using vim-plug
call plug#begin()
Plug 'Konfekt/FastFold'
call plug#end()

" Konfekt/FastFold
set foldmethod=syntax
set foldlevel=99 " Open all folds. Close them using 0
let g:fastfold_savehook = 1
let g:fastfold_fold_command_suffixes =  ['x', 'X', 'a', 'A', 'o', 'O', 'c', 'C']
let g:fastfold_fold_movement_commands = [']z', '[z', 'zj', 'zk']
let g:fastfold_minlines = 6
```