### PR TITLE
Better Fold Text-Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ Replace the standard `&foldtext`
 Create a fold text object, mapped to `iz` and `az`, by adding the lines
 
 ```vim
-xnoremap iz :<c-u>FastFoldUpdate<cr><esc>:<c-u>normal! ]zv[z<cr>
-xnoremap az :<c-u>FastFoldUpdate<cr><esc>:<c-u>normal! ]zV[z<cr>
+xnoremap <silent> iz :<c-u>FastFoldUpdate<cr>]z<up>$v[z<down>^
+xnoremap <silent> az :<c-u>FastFoldUpdate<cr>]zV[z
 ```
 
 to the file `~/.vimrc` (respectively `%USERPROFILE%/_vimrc` on Microsoft Windows).


### PR DESCRIPTION
Before, the <kbd>esc</kbd> and `:normal` was unnecessary because it's already in the normal mode and will create a bell. The original `viz` will select the beginning marker if the foldmethod was `syntax` or `marker`. Now, it will select the real `inner` as long as the content starts in the next line of the beginning marker.